### PR TITLE
Fix add_repl_definitions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ex.:
 iron.core.add_repl_definitions{
   python = {
     mycustom = {
-      command = "mycmd"
+      command = {"mycmd"}
     }
   }
 }


### PR DESCRIPTION
Hello,

Thank you for making this plugin. This PR fixes a small mistake in the `add_repl_definitions` example in the README. Without braces surrounding the REPL command, neovim complains:

```
E5105: Error while calling lua chunk: /home/***/.nvim/plugged/iron.nvim//lua/iron/init.lua:91: Vim:E119: Not enough arguments for function: exepath
```