### PR TITLE
Let focus remain in the edit buffer after a repl window is created.

### DIFF
--- a/lua/iron/init.lua
+++ b/lua/iron/init.lua
@@ -163,6 +163,8 @@ iron.core.repl_for = function(ft)
       iron.ll.new_repl_window('b ' .. mem.bufnr)
     end
     iron.config.visibility(mem.bufnr, showfn)
+  else
+    nvim.nvim_command('wincmd p')
   end
 
   return mem

--- a/lua/iron/visibility.lua
+++ b/lua/iron/visibility.lua
@@ -22,6 +22,8 @@ visibility.toggle = function(bufid, showfn)
   local window, was_hidden = hidden(bufid, showfn)
   if not was_hidden then
     nvim.nvim_command(window .. "wincmd c")
+  else
+    nvim.nvim_command(window .. "wincmd p")
   end
 end
 


### PR DESCRIPTION
Focus will remain in the edit buffer when a repl window is created or shown.

For single mode, the focus will switch to repl -- assuming it is what the user asks for.