### PR TITLE
Add '--no-autoindent' as a default for ipython

### DIFF
--- a/lua/iron/fts/python.lua
+++ b/lua/iron/fts/python.lua
@@ -9,7 +9,7 @@ local def = function(cmd)
 end
 
 python.ptipython = def({"ptipython"})
-python.ipython = def({"ipython"})
+python.ipython = def({"ipython", "--no-autoindent"})
 python.ptpython = def({"ptpython"})
 python.python = {
   command = {"python"},


### PR DESCRIPTION
Fixes #122.