### PR TITLE
Updated python format fixup

### DIFF
--- a/lua/iron/fts/python.lua
+++ b/lua/iron/fts/python.lua
@@ -1,26 +1,24 @@
 local extend = require("iron.util.tables").extend
 local python = {}
 
-local format = function(open, close)
+local format = function(open, close, cr)
   return function(lines)
-    local new = {
-      open .. lines[1]
-    }
-
-    for line=2, #lines - 1 do
-      table.insert(new, lines[line])
+    if #lines == 1 then
+      return { lines[1] .. cr }
+    else
+      local new = { open .. lines[1] }
+      for line=2, #lines do
+        table.insert(new, lines[line])
+      end
+      return extend(new, close)
     end
-
-    new[#lines] = lines[#lines] .. close
-    return new
   end
-
 end
 
 local def = function(cmd)
   return {
     command = cmd,
-    format = format("\27[200~", "\27[201~\13")
+    format = format("\27[200~", "\27[201~\13", "\13")
   }
 end
 


### PR DESCRIPTION
* Revert to previous behavior for multi line case.
* Do not use multi line markers for single line paste.

Previous solution unfortunately caused some error:

when pasting
```
print
```
the result was
```
In [1]: prinT
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-1-20ad6d819173> in <module>()
----> 1 prinT

NameError: name 'prinT' is not defined

In [2]:
```
looks like for single line just appending '\13' works without issue