### PR TITLE
Start and restart REPL in same window

### DIFF
--- a/plugin/iron.vim
+++ b/plugin/iron.vim
@@ -23,6 +23,15 @@ command! -nargs=? -complete=filetype IronFocus
       \ .(empty(<q-args>) ? &ft : <q-args>)
       \ .'")'
 
+" add additional commands to open a REPL in the current buffer and to restart
+" a REPL
+command! -nargs=1 -complete=filetype IronReplHere 
+    \ exec 'lua require("iron").core.repl_here("'
+    \ .(<q-args>)
+    \ .'")'
+command! IronRestart exec 'lua require("iron").core.repl_restart()'
+
+
 map <silent> <Plug>(iron-repeat-cmd)   :lua require("iron").core.repeat_cmd()<CR>
 map <silent> <Plug>(iron-cr)            <Cmd>IronSend! \13<CR>
 map <silent> <Plug>(iron-interrupt)     <Cmd>IronSend! \03<CR>


### PR DESCRIPTION
- Ability to start a REPL in the current window. This does not open a new window and therefore does not change the current layout (see command IronReplHere - expects a filetype as argument
- Ability to restart a REPL. When focus is on a window with a REPL, kills the REPL in there and restarts one for the same type. If the currently active buffer is not a REPL, throws an error