### PR TITLE
Fix elm repl command

### DIFF
--- a/lua/iron/fts/elm.lua
+++ b/lua/iron/fts/elm.lua
@@ -1,6 +1,10 @@
 local elm = {}
 
 elm.elm = {
+  command = {"elm", "repl"},
+}
+
+elm.elm_legacy = {
   command = {"elm-repl"},
 }
 


### PR DESCRIPTION
This should fix the elm repl command (as per described in #142) and also creates a backup for the old version for those who still didn't update.