### PR TITLE
Python REPL improvements

### DIFF
--- a/lua/iron/fts/python.lua
+++ b/lua/iron/fts/python.lua
@@ -1,6 +1,24 @@
 local extend = require("iron.util.tables").extend
 local python = {}
 
+local has = function(feature)
+  return vim.api.nvim_call_function('has', {feature}) == 1
+end
+
+local executable = function(exe)
+  return vim.api.nvim_call_function('executable', {exe}) == 1
+end
+
+local windows_linefeed = function(lines)
+  for idx,line in ipairs(lines) do
+    lines[idx] = line .. '\13'
+  end
+  return lines
+end
+
+local is_windows = has('win32') and true or false
+local pyversion  = executable('python3') and 'python3' or 'python'
+
 local format = function(open, close, cr)
   return function(lines)
     if #lines == 1 then
@@ -26,8 +44,12 @@ python.ptipython = def({"ptipython"})
 python.ipython = def({"ipython", "--no-autoindent"})
 python.ptpython = def({"ptpython"})
 python.python = {
-  command = {"python"},
+  command = {pyversion},
   close = {""}
 }
+
+if is_windows then
+  python.python.format = windows_linefeed
+end
 
 return python


### PR DESCRIPTION
- Fix #146 
- Prefer `python3` over `python`