### PR TITLE
Fix error that occurs when `close_window_on_exit = false`

### DIFF
--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -72,6 +72,8 @@ ll.create_repl_on_current_window = function(ft, repl, bufnr, current_bufnr, opts
       end
       vim.api.nvim_buf_delete(bufnr, {force = true})
     end
+  else
+    opts.on_exit = function() end
   end
 
   local cmd = repl.command


### PR DESCRIPTION
The error below occurs when `send_line()` or `send_file()` is executed with `close_window_on_exit = false`.

```log
E5108: Error executing lua $HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:46: Vim:E475: Invalid argument: expected dictionary
stack traceback:
  [C]: in function 'error'
  $HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:46: in function 'create'
  $HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:60: in function 'create_on_new_window'
  $HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:178: in function 'repl_for'
  $HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:219: in function 'send'
  $HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:245: in function 'send_line'
  [string ":lua"]:1: in main chunk
```

This error was thrown when an empty dictionary is assigned to `on_exit`:
```log
E5108: Error executing lua $HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:46: Vim:E6000: Argument is not a function or function name
stack traceback:
	[C]: in function 'error'
	$HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:46: in function 'create'
	$HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:60: in function 'create_on_new_window'
	$HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:178: in function 'repl_for'
	$HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:219: in function 'send'
	$HOME/.vim/plugged/iron.nvim/lua/iron/core.lua:225: in function 'send_file'
	[string ":lua"]:1: in main chunk
```

The change resolved the issue for me, but please feel free to close the PR if you believe it's not the appropriate way to fix the issue.