### PR TITLE
fix: improve logics on handling attached REPLs created by `core.attach`.

### DIFF
--- a/lua/iron/fts/markdown.lua
+++ b/lua/iron/fts/markdown.lua
@@ -1,36 +1,8 @@
 local markdown = {}
 
-local function replace_tab_by_spaces(line)
-  local spaces = string.rep(" ", 8)
-  return string.gsub(line, "\t", spaces)
-end
-
-local aichat_format = function(lines)
-  local cr = "\13"
-  local open_code = "{"
-  local close_code = "}"
-  -- aichat currently use `{` and `}`
-  -- to determine whether it is multi line input.
-  -- aichat uses tab for invoking completion,
-  -- there's no way to insert a real tab,
-  -- we can only replace tab by spaces.
-  if #lines == 1 then
-    return { replace_tab_by_spaces(lines[1]) .. cr }
-  else
-    local new = { open_code .. replace_tab_by_spaces(lines[1]) .. cr }
-    for line = 2, #lines do
-      table.insert(new, replace_tab_by_spaces(lines[line]) .. cr)
-    end
-
-    table.insert(new, close_code .. cr)
-
-    return new
-  end
-end
-
 markdown.aichat = {
   command = "aichat",
-  format = aichat_format,
+  format = require("iron.fts.common").bracketed_paste,
 }
 
 return markdown


### PR DESCRIPTION
Currently, suppose you have created an attached REPL via `IronAttach` and later close this REPL, then the next time you want to call `iron.send` (either send line, send motion or whatever), iron will throw an error because the buffer local value `repl` has been created but it points to an REPL that does not exist.

And for `core.close_repl`, the logic should work similarly like `core.send` but the older patch that added the `IronAttach` command doesn't change the logic of `core.close_repl` to make it take care of the attached REPLs.

This patch improves the logic on handling those situations.

