### PR TITLE
fix(python): python REPL detection is broken

### DIFF
--- a/lua/iron/fts/python.lua
+++ b/lua/iron/fts/python.lua
@@ -18,14 +18,7 @@ local windows_linefeed = function(lines)
 end
 
 local is_windows = has('win32') and true or false
-
-local pyversion
-if os.getenv('VIRTUAL_ENV') ~= nil then
-    pyversion = 'python'
-else
-    pyversion = executable('python3') and 'python3' or 'python'
-end
-
+local pyversion  = executable('python3') and 'python3' or 'python'
 
 local def = function(cmd)
   return {
@@ -34,9 +27,9 @@ local def = function(cmd)
   }
 end
 
-python.ptipython = def({pyversion, "-m", "ptpython.entry_points.run_ptipython"})
-python.ipython = def({pyversion, "-m", "IPython", "--no-autoindent"})
-python.ptpython = def({pyversion, "-m", "ptpython"})
+python.ptipython = def({"ptipython"})
+python.ipython = def({"ipython", "--no-autoindent"})
+python.ptpython = def({"ptpython"})
 python.python = {
   command = {pyversion},
   close = {""}


### PR DESCRIPTION
Hi @hkupty @Palpatineli 

As I've mentioned in #344, the current state of this plugin is broken with a bug in detection mechanism.

> no it did not occur to me that a change to the start up repl script would interfere with the selection script due to my ignorance of how the selection script works

As stated by @Palpatineli in https://github.com/Vigemus/iron.nvim/issues/344#issuecomment-1599156324, he acknowledges that he may have overlooked this issue and has not provided any further response. Therefore, I kindly suggest reconsidering his change.

I regret to admit that the current state of this plugin is severely disrupting my workflow. I apologize for any negativity I may have displayed earlier, but I respectfully request that his PR be reverted as soon as possible.

Closes: #344

Best,