### PR TITLE
fix: indentation problem in python windows

### DIFF
--- a/lua/iron/fts/python.lua
+++ b/lua/iron/fts/python.lua
@@ -3,22 +3,10 @@ local bracketed_paste = require("iron.fts.common").bracketed_paste
 local bracketed_paste_python = require("iron.fts.common").bracketed_paste_python
 local python = {}
 
-local has = function(feature)
-  return vim.api.nvim_call_function('has', {feature}) == 1
-end
-
 local executable = function(exe)
   return vim.api.nvim_call_function('executable', {exe}) == 1
 end
 
-local windows_linefeed = function(lines)
-  for idx,line in ipairs(lines) do
-    lines[idx] = line .. '\13'
-  end
-  return lines
-end
-
-local is_windows = has('win32') and true or false
 local pyversion  = executable('python3') and 'python3' or 'python'
 
 local def = function(cmd)
@@ -36,9 +24,5 @@ python.python = {
   format = bracketed_paste_python,
   close = {""}
 }
-
-if is_windows then
-  python.python.format = windows_linefeed
-end
 
 return python


### PR DESCRIPTION
remove windows check and windows-specific linefeed since bracketed_paste_python works on windows and fixes indentation problem

this example code:
```python
class clase:
    def __init__(self, name: str | None = None):
        self.name = name if name is not None else "example"

    def print_name(self):
        for i in range(3):
            print("printing name in " + str(i))
        print(self.name)

def example(x):
    print("example", x)

example("hola")
new_clase = clase("class")
new_clase.print_name()
```

breaks with the windows linefeed

```
Python 3.10.11 (tags/v3.10.11:7d4cc5a, Apr  5 2023, 00:38:17) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.       
>>> class clase:
...
  File "<stdin>", line 2

    ^
IndentationError: expected an indented block after class definition on line 1
>>>     def __init__(self, name: str | None = None):
  File "<stdin>", line 1
    def __init__(self, name: str | None = None):
IndentationError: unexpected indent
>>>
>>>         self.name = name if name is not None else "example"
  File "<stdin>", line 1
    self.name = name if name is not None else "example"
IndentationError: unexpected indent
>>>
>>>     def print_name(self):
  File "<stdin>", line 1
    def print_name(self):
IndentationError: unexpected indent
>>>
>>>         for i in range(3):
  File "<stdin>", line 1
    for i in range(3):
IndentationError: unexpected indent
>>>
>>>             print("printing name in " + str(i))
  File "<stdin>", line 1
    print("printing name in " + str(i))
IndentationError: unexpected indent
>>>
>>>         print(self.name)
  File "<stdin>", line 1
    print(self.name)
IndentationError: unexpected indent
>>>
>>> def example(x):
...
  File "<stdin>", line 2

    ^
IndentationError: expected an indented block after function definition on line 1
>>>     print("example", x)
  File "<stdin>", line 1
    print("example", x)
IndentationError: unexpected indent
>>>
>>> example("hola")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'example' is not defined
>>>
>>> new_clase = clase("class")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'clase' is not defined
>>>
>>> new_clase.print_name()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'new_clase' is not defined
>>>

```

 but works with bracketed_paste_python
```
Python 3.10.11 (tags/v3.10.11:7d4cc5a, Apr  5 2023, 00:38:17) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> class clase:
...     def __init__(self, name: str | None = None):
...         self.name = name if name is not None else "example"       
...     def print_name(self):
...         for i in range(3):
...             print("printing name in " + str(i))
...         print(self.name)
...
>>>
>>> def example(x):
...     print("example", x)
...
>>>
>>> example("hola")
example hola
>>> new_clase = clase("class")
>>> new_clase.print_name()
printing name in 0
printing name in 1
printing name in 2
class
>>>
>>>
```