### PR TITLE
send paragraph, issue 351, windows powershell indentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ iron.setup {
     visual_send = "<space>sc",
     send_file = "<space>sf",
     send_line = "<space>sl",
+    send_paragraph = "<space>sp",
     send_until_cursor = "<space>su",
     send_mark = "<space>sm",
     mark_motion = "<space>mc",

--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -396,6 +396,15 @@ core.visual_send = function()
   core.send(nil, core.mark_visual())
 end
 
+--- Sends the paragraph to the REPL that the cursor is on
+core.send_paragraph = function()
+  vim.cmd('normal! vip')
+  vim.defer_fn(function()
+    core.visual_send()
+  end, 100)
+end
+
+
 --- Re-sends latest chunk of text.
 -- Sends text contained within a block delimited by
 -- the last sent chunk. Uses @{marks.get} to retrieve
@@ -581,6 +590,7 @@ local named_maps = {
   send_until_cursor = {{'n'}, core.send_until_cursor},
   send_file = {{'n'}, core.send_file},
   visual_send = {{'v'}, core.visual_send},
+  send_paragraph = {{'n'}, core.send_paragraph},
 
   -- Marks
   mark_motion = {{'n'}, function() require("iron.core").run_motion("mark_motion") end},

--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -1,3 +1,4 @@
+local config = require("iron.config")
 local isWindows = require("iron.util.os").isWindows
 local extend = require("iron.util.tables").extend
 local open_code = "\27[200~"
@@ -5,6 +6,18 @@ local close_code = "\27[201~"
 local cr = "\13"
 
 local common = {}
+
+
+local contains = function(table, substring)
+  for _, v in ipairs(table) do
+    if string.find(v, substring) then
+      print("found")
+      return true
+    end
+  end
+  return false
+end
+
 
 common.format = function(repldef, lines)
   assert(type(lines) == "table", "Supplied lines is not a table")
@@ -56,9 +69,17 @@ common.bracketed_paste_python = function(lines)
     if i < #lines then
       local current_line_has_indent = string.match(line, "^%s") ~= nil
       local next_line_has_indent = string.match(lines[i + 1], "^%s") ~= nil
-       
-      if current_line_has_indent and not next_line_has_indent then
-        table.insert(result, cr)
+
+      if isWindows() then
+        if not contains(config.repl_definition.python.command, "ipython") then
+          if current_line_has_indent and not next_line_has_indent then
+            table.insert(result, cr)
+          end
+        end
+      else
+        if current_line_has_indent and not next_line_has_indent then
+          table.insert(result, cr)
+        end
       end
 
     end

--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -1,3 +1,4 @@
+local isWindows = require("iron.util.os").isWindows
 local extend = require("iron.util.tables").extend
 local open_code = "\27[200~"
 local close_code = "\27[201~"
@@ -19,7 +20,9 @@ common.format = function(repldef, lines)
   end
 
   if #new > 0 then
-    new[#new] = new[#new] .. cr
+    if not isWindows() then
+      new[#new] = new[#new] .. cr
+    end
   end
 
   return new
@@ -53,15 +56,20 @@ common.bracketed_paste_python = function(lines)
     if i < #lines then
       local current_line_has_indent = string.match(line, "^%s") ~= nil
       local next_line_has_indent = string.match(lines[i + 1], "^%s") ~= nil
-
-      if current_line_has_indent and not next_line_has_indent then
-        table.insert(result, cr)
+       
+      if not isWindows() then
+        if current_line_has_indent and not next_line_has_indent then
+          table.insert(result, cr)
+        end
       end
 
     end
   end
+  
+  if not isWindows() then
+    table.insert(result, cr)
+  end
 
-  table.insert(result, cr)
   return result
 end
 

--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -57,10 +57,8 @@ common.bracketed_paste_python = function(lines)
       local current_line_has_indent = string.match(line, "^%s") ~= nil
       local next_line_has_indent = string.match(lines[i + 1], "^%s") ~= nil
        
-      if not isWindows() then
-        if current_line_has_indent and not next_line_has_indent then
-          table.insert(result, cr)
-        end
+      if current_line_has_indent and not next_line_has_indent then
+        table.insert(result, cr)
       end
 
     end

--- a/lua/iron/fts/python.lua
+++ b/lua/iron/fts/python.lua
@@ -1,5 +1,4 @@
 -- luacheck: globals vim
-local bracketed_paste = require("iron.fts.common").bracketed_paste
 local bracketed_paste_python = require("iron.fts.common").bracketed_paste_python
 local python = {}
 
@@ -24,18 +23,14 @@ local pyversion  = executable('python3') and 'python3' or 'python'
 local def = function(cmd)
   return {
     command = cmd,
-    format = bracketed_paste
+    format = bracketed_paste_python
   }
 end
 
 python.ptipython = def({"ptipython"})
 python.ipython = def({"ipython", "--no-autoindent"})
 python.ptpython = def({"ptpython"})
-python.python = {
-  command = {pyversion},
-  format = bracketed_paste_python,
-  close = {""}
-}
+python.python = def({pyversion})
 
 if is_windows then
   python.python.format = windows_linefeed

--- a/lua/iron/util/os.lua
+++ b/lua/iron/util/os.lua
@@ -1,0 +1,7 @@
+local checks = {}
+
+checks.isWindows = function()
+    return package.config:sub(1,1) == '\\'
+end
+
+return checks

--- a/lua/iron/util/os.lua
+++ b/lua/iron/util/os.lua
@@ -4,4 +4,9 @@ checks.isWindows = function()
     return package.config:sub(1,1) == '\\'
 end
 
+
+checks.has = function(feature)
+  return vim.api.nvim_call_function('has', {feature}) == 1
+end
+
 return checks


### PR DESCRIPTION
1. A "send paragraph" feature is now available and the README has been updated. see `core.send_paragraph`

2. Issue 351 is fixed. windows ipython now will run the code upon being sent to the repl. 

3. Windows powershell now will run python code without the indentation errors.

Both 2 and 3 above required slight edits to `core.send` which wont affect prior setups. 