### PR TITLE
bug fix: cyclic dependency causing sendline errors

### DIFF
--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -1,4 +1,3 @@
-local config = require("iron.config")
 local is_windows = require("iron.util.os").is_windows
 local extend = require("iron.util.tables").extend
 local open_code = "\27[200~"
@@ -94,9 +93,9 @@ end
 --- @param lines table  "each item of the table is a new line to send to the repl"
 --- @return table  "returns the table of lines to be sent the the repl with
 -- the return carriage added"
-common.bracketed_paste_python = function(lines)
+common.bracketed_paste_python = function(lines, cmd)
   local result = {}
-  local is_ipython = contains(config.repl_definition.python.command, "ipython")
+  local is_ipython = contains(cmd, "ipython")
 
   lines = remove_empty_lines(lines)
 

--- a/lua/iron/fts/python.lua
+++ b/lua/iron/fts/python.lua
@@ -9,10 +9,12 @@ end
 local pyversion  = executable('python3') and 'python3' or 'python'
 
 local def = function(cmd)
-  return {
-    command = cmd,
-    format = bracketed_paste_python
-  }
+	return {
+		command = cmd,
+		format = function(line)
+			return bracketed_paste_python(line, cmd)
+		end,
+	}
 end
 
 python.ptipython = def({"ptipython"})


### PR DESCRIPTION
Sending a line via `send_line` would prop up errors (see #379). Passing `cmd` via an anonymous function wrapper fixes it while avoiding the extra `require` call.
