### PR TITLE
Refactor of #382

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ iron.setup {
         -- Can be a table or a function that
         -- returns a table (see below)
         command = {"zsh"}
+      },
+      python = {
+        command = { "python3" },  -- or { "ipython", "--no-autoindent" }
+        format = require("iron.fts.common").bracketed_paste_python
       }
     },
     -- How the repl window will be displayed

--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -55,8 +55,8 @@ common.format = function(repldef, lines)
   assert(type(lines) == "table", "Supplied lines is not a table")
 
   local new
-  
-  -- the passing command is for python. this will not affect bracket_paste
+
+  -- passing the command is for python. this will not affect bracketed_paste.
   if repldef.format then
     return repldef.format(lines, { command = repldef.command })
   elseif #lines == 1 then

--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -55,9 +55,10 @@ common.format = function(repldef, lines)
   assert(type(lines) == "table", "Supplied lines is not a table")
 
   local new
-
+  
+  -- the passing command is for python. this will not affect bracket_paste
   if repldef.format then
-    return repldef.format(lines)
+    return repldef.format(lines, { command = repldef.command })
   elseif #lines == 1 then
     new = lines
   else
@@ -93,8 +94,9 @@ end
 --- @param lines table  "each item of the table is a new line to send to the repl"
 --- @return table  "returns the table of lines to be sent the the repl with
 -- the return carriage added"
-common.bracketed_paste_python = function(lines, cmd)
+common.bracketed_paste_python = function(lines, extras)
   local result = {}
+  local cmd = extras["command"]
   local is_ipython = contains(cmd, "ipython")
 
   lines = remove_empty_lines(lines)

--- a/lua/iron/fts/python.lua
+++ b/lua/iron/fts/python.lua
@@ -11,9 +11,7 @@ local pyversion  = executable('python3') and 'python3' or 'python'
 local def = function(cmd)
 	return {
 		command = cmd,
-		format = function(line)
-			return bracketed_paste_python(line, cmd)
-		end,
+		format = bracketed_paste_python
 	}
 end
 


### PR DESCRIPTION
Commit #382 fixed a bug that required the user to manually state the `repl_definition` for `python`. However, #382 changed `common.bracketed_paste_python` in a way that would have broke users setups. This commit applies the same logic of #382, but will not break prior user's setups.

Additionally, I added a suggested `python` setup to the README.