### PR TITLE
Enable bracketed paste mode when sending lines to the repl

### DIFF
--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -164,7 +164,10 @@ ll.send_to_repl = function(meta, data)
 
   --TODO check vim.api.nvim_chan_send
   --TODO tool to get the progress of the chan send function
+  vim.fn.chansend(meta.job, "\x1b[200~")
   vim.fn.chansend(meta.job, dt)
+  vim.fn.chansend(meta.job, "\x1b[201~")
+  vim.fn.chansend(meta.job, "\n")
 
   if window ~= -1 then
     vim.api.nvim_win_set_cursor(window, {vim.api.nvim_buf_line_count(meta.bufnr), 0})


### PR DESCRIPTION
# The problem
Recently, after returning to some Python projects, I noticed a problem with iron.nvim's core.send_file() function. While the function still pushes all lines to the REPL buffer, each line's indentation increases by one. This issue arose in my environment where I'm using ptpython on macOS.

# The fix
Upon investigating, it appears the issue stems from lowlevel.send_to_repl(). The function wasn't initiating bracket paste mode, which seems to be the root of the problem. I implemented a patch that triggers bracketed paste mode before sending code to the REPL, which resolved the issue in my setup. While I'm not certain if this issue is widespread or what other setups it might impact, this solution has worked well for me so far.

I hope this fix can be helpful to others experiencing similar issues!