### PR TITLE
Fixes problems with ReplRestart

### DIFF
--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -118,7 +118,7 @@ core.repl_restart = function()
       else
         vim.api.nvim_set_current_win(replwin)
         local bufnr = ll.new_buffer()
-        meta = new_repl.create(ft, bufnr, current_bufnr, function()
+        new_meta = new_repl.create(ft, bufnr, current_bufnr, function()
           vim.api.nvim_buf_delete(bufnr, {force = true})
         end)
       end

--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -70,7 +70,9 @@ ll.create_repl_on_current_window = function(ft, repl, bufnr, current_bufnr, opts
         vim.api.nvim_win_close(bufwinid, true)
         bufwinid = vim.fn.bufwinid(bufnr)
       end
-      vim.api.nvim_buf_delete(bufnr, {force = true})
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
     end
   else
     opts.on_exit = function() end


### PR DESCRIPTION
If one opens a REPL and then Restarts a REPL, one gets errors about wrong buffer ids.

The reason is that core.repl_restart deletes the old buffer. But the default of close_window_on_exit, will try to delete it too.

Also if one calls IronRestart from a code buffer, changes are done to meta, but new_meta is returned.

I made a commit that fixes this, by not altering meta, but altering new_meta.
Also it will be checked in the on exit option, whether the buffer still exist.

I will create a merge request.

I also observed that many functions will differ strongly whether the cursor is on code buffer or repl buffer. One could change that if the get_ft would check on empty file type, if the buffer is the buffer of a repl and then use the ft from store.
I checked that, but I am unsure whether this could have some side effects.

See https://github.com/Vigemus/iron.nvim/issues/387#issue-2471884954