### PR TITLE
Fix: Treat REPL buffer filetype as filetype for repl

### DIFF
--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -493,7 +493,13 @@ local get_ft = function(arg)
   if arg and arg ~= "" then
     return arg
   end
-  return ll.get_buffer_ft(0)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local ft = ll.get_repl_ft_for_bufnr(bufnr)
+  if ft ~= nil then
+    return ft
+  else
+    return ll.get_buffer_ft(0)
+  end
 end
 
 --- List of commands created by iron.nvim


### PR DESCRIPTION
Currently many commands only work if the cursor is on the repl buffer or on a code buffer with fitting filetype.
This is inconvenient, because one can't call IronHide, if focus is on repl and one can't call IronFocus, if cursor is on repl etc.

This fix checks if the current buffer is a repl buffer and returns the filetype that the repl was created for.

See also https://github.com/Vigemus/iron.nvim/issues/323#issue-1626950783 for example.