### PR TITLE
feat: core.send_code_block

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ iron.setup {
       },
       python = {
         command = { "python3" },  -- or { "ipython", "--no-autoindent" }
-        format = require("iron.fts.common").bracketed_paste_python
+        format = require("iron.fts.common").bracketed_paste_python,
+        block_deviders = { "# %%", "#%%" },
       }
     },
     -- How the repl window will be displayed
@@ -61,6 +62,8 @@ iron.setup {
     send_paragraph = "<space>sp",
     send_until_cursor = "<space>su",
     send_mark = "<space>sm",
+    send_code_block = "<space>sb",
+    send_code_block_and_move = "<space>sn",
     mark_motion = "<space>mc",
     mark_visual = "<space>mc",
     remove_mark = "<space>md",

--- a/doc/iron.txt
+++ b/doc/iron.txt
@@ -155,6 +155,12 @@ Below are the core functions:
 
 * core.send(ft, data)        Sends data (a table) to the repl for given filetype
 
+* core.send_code_block(move) Sends the lines between two code_deviders as defined 
+                             in repl_definition or end and start of buffer to the 
+                             repl. If move is true, the cursor is moved to next 
+                             code block. If move is false, the cursor position is 
+                             unchanged.
+
 * core.send_file()           Sends the whole file to the repl
 
 * core.send_line()           Sends line below the cursor to the repl
@@ -217,6 +223,12 @@ iron.setup{
         -- Can be a table or a function that returns a table (see below)
         command = {"my-lua-repl", "-arg"}
       }
+     -- setting up code_deviders for core.send_code_block
+      python = {
+        command = { "python3" }, -- or { "ipython", "--no-autoindent" }
+        format = require("iron.fts.common").bracketed_paste_python,
+        block_deviders = { "# %%", "#%%" },
+      }
     },
     -- Whether iron should map the `<plug>(..)` mappings
     should_map_plug = true,
@@ -246,6 +258,8 @@ iron.setup{
     send_line = "<space>sl",
     send_until_cursor = "<space>su",
     send_mark = "<space>sm",
+    send_code_block = "<space>sb",
+    send_code_block_and_move = "<space>sn",
     mark_motion = "<space>mc",
     mark_visual = "<space>mc",
     remove_mark = "<space>md",
@@ -293,6 +307,8 @@ core.setup function.
 - send_line: Sends the line below the cursor to the repl
 - send_until_cursor: Sends the buffer from the start until the line where the cursor is (inclusive) to the repl
 - send_mark: Sends the text within the mark
+- send_code_block: Sends the text between two code deviders
+- send_code_block_and_move: Sends the text between two code deviders and move to next code block
 - mark_motion: Marks the text object
 - mark_visual: Marks the visual selection
 - remove_mark: Removes the set mark

--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -461,6 +461,58 @@ core.send_mark = function()
   core.send(nil, lines)
 end
 
+--- Checks if line starts with a devider.
+-- Helper function for core.send_code_block.
+local line_starts_with_block_devider = function(line, block_deviders)
+  for _, block_devider in pairs(block_deviders) do
+    local length_block_devider = string.len(block_devider)
+    if string.sub(line, 1, length_block_devider) == block_devider then return true end
+  end
+end
+
+--- Sends lines between two block deviders.
+-- Block deviders can be defined as table in the 
+-- repl_definition under key block_deviders.
+-- The buffer is scanned from cursor till first line
+-- starting with a block_devider or the start of buffer.
+-- The buffer is scanned till end of buffer for next line
+-- starting with a block devider or end of buffer.
+-- If no block_devider is defined an error is returned.
+-- If move is true, the cursor is moved to the next block_devider
+-- for jumping through the code. If move is false, the cursor is
+-- not moved.
+core.send_code_block = function(move)
+  local block_deviders = config.repl_definition[vim.bo[0].filetype].block_deviders
+  if block_deviders == nil then
+    error("No block_deviders defined for this repl in repl_definition!")
+  end
+  local linenr = vim.api.nvim_win_get_cursor(0)[1] - 1
+  local buffer_text = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local mark_start = linenr
+  while mark_start ~= 0 do
+    local line_text = buffer_text[mark_start + 1]
+    if line_starts_with_block_devider(line_text, block_deviders) then break end
+    mark_start = mark_start - 1
+  end
+  local buffer_length = vim.api.nvim_buf_line_count(0)
+  local mark_end = linenr + 1
+  while mark_end < buffer_length do
+    local line_text = buffer_text[mark_end + 1]
+    if line_starts_with_block_devider(line_text, block_deviders) then break end
+    mark_end = mark_end + 1
+  end
+  mark_end = mark_end - 1
+  local col_end = string.len(buffer_text[mark_end + 1]) - 1
+  marks.set {
+    from_line = mark_start,
+    from_col = 0,
+    to_line = mark_end,
+    to_col = col_end,
+  }
+  core.send_mark()
+  if move then vim.api.nvim_win_set_cursor(0, { math.min(mark_end + 2, buffer_length), 0 }) end
+end
+
 --- Attaches a buffer to a repl regardless of it's filetype
 -- If the repl doesn't exist it will be created
 core.attach = function(ft, target)
@@ -620,6 +672,8 @@ local named_maps = {
   send_file = {{'n'}, core.send_file},
   visual_send = {{'v'}, core.visual_send},
   send_paragraph = {{'n'}, core.send_paragraph},
+  send_code_block = {{'n'}, function() require("iron.core").send_code_block(false) end},
+  send_code_block_and_move = {{'n'}, function() require("iron.core").send_code_block(true) end},
 
   -- Marks
   mark_motion = {{'n'}, function() require("iron.core").run_motion("mark_motion") end},


### PR DESCRIPTION
Editors like vscode or pycharm or tools like jupyter notebooks let you send code blocks devided by a delimiter, eg. in python '#%%' or '# %%' to the repl.

The plugin jupytext is also to mention here, as it creates a .py representation of jupyter notebooks, in which in case of the py:percent style, the code blocks are delimited with '# %%'.

I wrote this feature which lets you define multiple code_deviders in the repl_definition and let you send the lines between those to the repl. Optionally one can choose to move the cursor to the next block in order to iterate easily through the file.

I also updated the doc and the readme to reflect for the changes and included two commands to the core.named_maps.

I hope you like, what I did here, and see the comfortable workflow provided by it.

I asked here https://github.com/Vigemus/iron.nvim/discussions/386#discussion-7045785, whether this would be possible, but then had fun, implementing it myself.