### PR TITLE
fix: drop useless/harmful nvim_set_hl_ns

### DIFF
--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -663,8 +663,7 @@ core.setup = function(opts)
     }
 
 
-    (vim.api.nvim__set_hl_ns or vim.api.nvim_set_hl_ns)(config.namespace)
-    vim.api.nvim_set_hl(config.namespace, config.highlight_last, hl_cfg)
+    vim.api.nvim_set_hl(0, config.highlight_last, hl_cfg)
   end
 
   for _, command in ipairs(commands) do


### PR DESCRIPTION
The highlight absolutely does not need to be in the same namespace as the extmarks, and we definitely do not need to globally change the highlight namespace, as that might interfere with other plugins or the user's config or whatever.

And it happens to break background colors in floats (such as LSP hover, diagnostic detail, completion help, etc.) due to a bug in neovim: https://github.com/neovim/neovim/issues/30262
