### PR TITLE
feat: set filetype of iron buffers to "iron"

### DIFF
--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -127,7 +127,9 @@ end
 --- Creates a new buffer to be used by the repl
 -- @return the buffer id
 ll.new_buffer = function()
-  return vim.api.nvim_create_buf(config.buflisted, config.scratch_repl)
+  local bufnr = vim.api.nvim_create_buf(config.buflisted, config.scratch_repl)
+  vim.bo[bufnr].filetype = "iron"
+  return bufnr
 end
 
 --- Wraps the condition checking of whether a repl exists


### PR DESCRIPTION
# Motivation

To be able to create autocmds when a repl buffer is either created or entered, and to be able to set buffer local keymaps, or do some other things that benefit from having an identifiable filetype set.