### PR TITLE
Stop sending extra newline to Python REPL if not needed

### DIFF
--- a/lua/iron/fts/common.lua
+++ b/lua/iron/fts/common.lua
@@ -119,10 +119,13 @@ common.bracketed_paste_python = function(lines, extras)
     end
   end
 
-  if is_windows() then
-    table.insert(result, "\r\n")
+  local newline = is_windows() and "\r\n" or cr
+  if result[#result]:sub(1, 1) == " " then
+    -- Since the last line of code is indented, the Python REPL
+    -- requires and extra newline in order to execute the code
+    table.insert(result, newline)
   else
-    table.insert(result, cr)
+    table.insert(result, "")
   end
 
   return result


### PR DESCRIPTION
Currently, an extra newline is sent to the Python REPL every time code is sent, even when it's just lines without indentation, which causes unnecessary spaces in the REPL in that case:

## Example

```python
# First, we run this line - send_line
print(3)

# Second, we select those 2 lines and run the selection - visual_send
import math
print(math.sqrt(16))

# Third, we select those 3 lines and run the selection - visual_send
def meow(a):
    if a == 0:
        return 0
```

### Results before the PR
Using `command = { "python" }`: (Note the two extra `>>>`)
```
Python 3.11.9 (main, Jul 21 2024, 12:28:01) [GCC 14.1.1 20240522] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> print(3)
3
>>>                                                # Unnecessary!
>>> import math
>>> print(math.sqrt(16))
4.0
>>>                                                # Unnecessary!
>>> def meow(a):
...     if a == 0:
...         return 0
... 
>>> 

```
Using `command = { "ipython", "--no-autoindent" }`: (Note the extra `In [2]:` and `In [4]:`)
```
Python 3.11.9 (main, Jul 21 2024, 12:28:01) [GCC 14.1.1 20240522]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.27.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: print(3)
3

In [2]:                                                # Unnecessary!

In [2]: import math

In [3]: print(math.sqrt(16))
4.0

In [4]:                                                # Unnecessary!

In [4]: def meow(a):
   ...:     if a == 0:
   ...:         return 0
   ...: 

In [5]: 
```
### Results after the PR
Using `command = { "python" }`:
```
Python 3.11.9 (main, Jul 21 2024, 12:28:01) [GCC 14.1.1 20240522] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> print(3)
3
>>> import math
>>> print(math.sqrt(16))
4.0
>>> def meow(a):
...     if a == 0:
...         return 0
... 
>>> 

```
Using `command = { "ipython", "--no-autoindent" }`:
```
Python 3.11.9 (main, Jul 21 2024, 12:28:01) [GCC 14.1.1 20240522]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.27.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: print(3)
3

In [2]: import math

In [3]: print(math.sqrt(16))
4.0

In [4]: def meow(a):
   ...:     if a == 0:
   ...:         return 0
   ...: 

In [5]: 

```