### PR TITLE
Addressing #390: Adding `repl_filetype` option to set the filetype of the REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ iron.setup {
         block_deviders = { "# %%", "#%%" },
       }
     },
+    -- set the file type of the newly created repl to ft
+    -- bufnr is the buffer id of the REPL and ft is the filetype of the 
+    -- language being used for the REPL. 
+    repl_filetype = function(bufnr, ft)
+      return ft
+      -- or return a string name such as the following
+      -- return "iron"
+    end,
     -- How the repl window will be displayed
     -- See below for more information
     repl_open_cmd = require('iron.view').bottom(40),

--- a/lua/iron/config.lua
+++ b/lua/iron/config.lua
@@ -42,6 +42,9 @@ local values = {
       end
     end
   }),
+  repl_filetype = function(bufnr, ft)
+    return "iron"
+  end,
   should_map_plug = false,
   repl_open_cmd = view.split.botright(40),
   current_view = 1,

--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -63,6 +63,11 @@ new_repl.create_on_new_window = function(ft)
     vim.api.nvim_buf_delete(bufnr, {force = true})
   end)
 
+  local filetype = config.repl_filetype(bufnr, ft)
+  if filetype ~= nil then
+    vim.api.nvim_set_option_value("filetype", filetype, { buf = bufnr })
+  end
+
   return meta
 end
 

--- a/lua/iron/lowlevel.lua
+++ b/lua/iron/lowlevel.lua
@@ -127,9 +127,7 @@ end
 --- Creates a new buffer to be used by the repl
 -- @return the buffer id
 ll.new_buffer = function()
-  local bufnr = vim.api.nvim_create_buf(config.buflisted, config.scratch_repl)
-  vim.bo[bufnr].filetype = "iron"
-  return bufnr
+  return vim.api.nvim_create_buf(config.buflisted, config.scratch_repl)
 end
 
 --- Wraps the condition checking of whether a repl exists


### PR DESCRIPTION
Taking the suggestions from @frere-jacques and @noprompt, I have added a `repl_filetype` hook for the user to set in their config to set the filetype of the repl.