### PR TITLE
Fix: Typo of "deviders" changed to "dividers"

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ iron.setup {
       python = {
         command = { "python3" },  -- or { "ipython", "--no-autoindent" }
         format = common.bracketed_paste_python,
-        block_deviders = { "# %%", "#%%" },
+        block_dividers = { "# %%", "#%%" },
       }
     },
     -- set the file type of the newly created repl to ft

--- a/doc/iron.txt
+++ b/doc/iron.txt
@@ -155,7 +155,7 @@ Below are the core functions:
 
 * core.send(ft, data)        Sends data (a table) to the repl for given filetype
 
-* core.send_code_block(move) Sends the lines between two code_deviders as defined 
+* core.send_code_block(move) Sends the lines between two code_dividers as defined 
                              in repl_definition or end and start of buffer to the 
                              repl. If move is true, the cursor is moved to next 
                              code block. If move is false, the cursor position is 
@@ -227,7 +227,7 @@ iron.setup{
       python = {
         command = { "python3" }, -- or { "ipython", "--no-autoindent" }
         format = require("iron.fts.common").bracketed_paste_python,
-        block_deviders = { "# %%", "#%%" },
+        block_dividers = { "# %%", "#%%" },
       }
     },
     -- Whether iron should map the `<plug>(..)` mappings

--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -505,22 +505,72 @@ core.send_code_block = function(move)
         error("No block_dividers defined for this repl in repl_definition!")
       end
   end
+  local start_block_dividers = block_dividers.start_dividers
+  local end_block_dividers = block_dividers.end_dividers
+  local using_start_end = start_block_dividers ~= nil and end_block_dividers ~= nil
+  if not using_start_end then
+      start_block_dividers = block_dividers
+      end_block_dividers = block_dividers
+  end
+  local include_start_divider = config.repl_definition[vim.bo[0].filetype].include_start_divider
+  include_start_divider = (include_start_divider == nil) or (include_start_divider == true)
+  local include_end_divider = config.repl_definition[vim.bo[0].filetype].include_end_divider
+  include_end_divider = (include_end_divider == true)
   local linenr = vim.api.nvim_win_get_cursor(0)[1] - 1
   local buffer_text = vim.api.nvim_buf_get_lines(0, 0, -1, false)
   local mark_start = linenr
-  while mark_start ~= 0 do
-    local line_text = buffer_text[mark_start + 1]
-    if line_starts_with_block_divider(line_text, block_dividers) then break end
-    mark_start = mark_start - 1
-  end
-  local buffer_length = vim.api.nvim_buf_line_count(0)
   local mark_end = linenr + 1
-  while mark_end < buffer_length do
-    local line_text = buffer_text[mark_end + 1]
-    if line_starts_with_block_divider(line_text, block_dividers) then break end
-    mark_end = mark_end + 1
+  local buffer_length = vim.api.nvim_buf_line_count(0)
+  if not using_start_end then
+      while mark_start ~= 0 do
+        local line_text = buffer_text[mark_start + 1]
+        if line_starts_with_block_divider(line_text, start_block_dividers) then break end
+        mark_start = mark_start - 1
+      end
+      
+      while mark_end < buffer_length do
+        local line_text = buffer_text[mark_end + 1]
+        if line_starts_with_block_divider(line_text, end_block_dividers) then break end
+        mark_end = mark_end + 1
+      end
+  else
+      local nesting = 0
+      local i = 0
+      while i < buffer_length do
+          local line_text = buffer_text[i + 1]
+          if line_starts_with_block_divider(line_text, start_block_dividers) then
+              if nesting == 0 then
+                  mark_start = i
+              end
+              nesting = nesting + 1
+          end
+          if line_starts_with_block_divider(line_text, end_block_dividers) then
+              if nesting == 1 then
+                  mark_end = i
+              end
+              nesting = nesting - 1
+              nesting = math.max(nesting, 0)
+          end
+          if mark_start <= linenr and linenr <= mark_end then break end
+          i = i + 1
+      end
+      if not (mark_start <= linenr and linenr <= mark_end) then 
+          return
+      end
   end
-  mark_end = mark_end - 1
+  if not include_start_divider then
+      mark_start = mark_start + 1
+  end
+  local next_start = mark_end
+  while next_start < buffer_length do
+    local line_text = buffer_text[next_start + 1]
+    if line_starts_with_block_divider(line_text, start_block_dividers) then break end
+    next_start = next_start + 1
+  end
+
+  if mark_end == buffer_length or not include_end_divider then
+      mark_end = mark_end - 1
+  end
   local col_end = string.len(buffer_text[mark_end + 1]) - 1
   marks.set {
     from_line = mark_start,
@@ -529,7 +579,7 @@ core.send_code_block = function(move)
     to_col = col_end,
   }
   core.send_mark()
-  if move then vim.api.nvim_win_set_cursor(0, { math.min(mark_end + 2, buffer_length), 0 }) end
+  if move then vim.api.nvim_win_set_cursor(0, { math.min(next_start + 1, buffer_length), 0 }) end
 end
 
 --- Attaches a buffer to a repl regardless of it's filetype

--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -477,44 +477,47 @@ core.send_mark = function()
   core.send(nil, lines)
 end
 
---- Checks if line starts with a devider.
+--- Checks if line starts with a divider.
 -- Helper function for core.send_code_block.
-local line_starts_with_block_devider = function(line, block_deviders)
-  for _, block_devider in pairs(block_deviders) do
-    local length_block_devider = string.len(block_devider)
-    if string.sub(line, 1, length_block_devider) == block_devider then return true end
+local line_starts_with_block_divider = function(line, block_dividers)
+  for _, block_divider in pairs(block_dividers) do
+    local length_block_divider = string.len(block_divider)
+    if string.sub(line, 1, length_block_divider) == block_divider then return true end
   end
 end
 
---- Sends lines between two block deviders.
--- Block deviders can be defined as table in the
--- repl_definition under key block_deviders.
+--- Sends lines between two block dividers.
+-- Block dividers can be defined as table in the
+-- repl_definition under key block_dividers (or block_deviders for backwards compatibility).
 -- The buffer is scanned from cursor till first line
--- starting with a block_devider or the start of buffer.
+-- starting with a block_divider or the start of buffer.
 -- The buffer is scanned till end of buffer for next line
--- starting with a block devider or end of buffer.
--- If no block_devider is defined an error is returned.
--- If move is true, the cursor is moved to the next block_devider
+-- starting with a block divider or end of buffer.
+-- If no block_divider is defined an error is returned.
+-- If move is true, the cursor is moved to the next block_divider
 -- for jumping through the code. If move is false, the cursor is
 -- not moved.
 core.send_code_block = function(move)
-  local block_deviders = config.repl_definition[vim.bo[0].filetype].block_deviders
-  if block_deviders == nil then
-    error("No block_deviders defined for this repl in repl_definition!")
+  local block_dividers = config.repl_definition[vim.bo[0].filetype].block_dividers
+  if block_dividers == nil then
+      block_dividers = config.repl_definition[vim.bo[0].filetype].block_deviders
+      if block_dividers == nil then
+        error("No block_dividers defined for this repl in repl_definition!")
+      end
   end
   local linenr = vim.api.nvim_win_get_cursor(0)[1] - 1
   local buffer_text = vim.api.nvim_buf_get_lines(0, 0, -1, false)
   local mark_start = linenr
   while mark_start ~= 0 do
     local line_text = buffer_text[mark_start + 1]
-    if line_starts_with_block_devider(line_text, block_deviders) then break end
+    if line_starts_with_block_divider(line_text, block_dividers) then break end
     mark_start = mark_start - 1
   end
   local buffer_length = vim.api.nvim_buf_line_count(0)
   local mark_end = linenr + 1
   while mark_end < buffer_length do
     local line_text = buffer_text[mark_end + 1]
-    if line_starts_with_block_devider(line_text, block_deviders) then break end
+    if line_starts_with_block_divider(line_text, block_dividers) then break end
     mark_end = mark_end + 1
   end
   mark_end = mark_end - 1


### PR DESCRIPTION
Originally, code was divided into blocks surrounded by some special strings such as "# %%" called dividers. For example:
`# %%
print("hello world")

# %%
print("goodbye")`
The divider string could be changed, specified in the config file.

The key `block_deviders` (typo with deviders) was used in the repl_definition to hold the values of the dividers. Extra code has been added so that the key `block_dividers` can also be used in addition to `block_deviders`. Both keys are accepted for backwards compatibility. `block_dividers` has a higher precedence to `block_deviders`.