### PR TITLE
Fix Clear REPL when using bracketed_paste_python formatter

### DIFF
--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -515,6 +515,10 @@ end
 -- for jumping through the code. If move is false, the cursor is
 -- not moved.
 core.send_code_block = function(move)
+  local repl_definition = config.repl_definition[vim.bo[0].filetype]
+  if repl_definition == nil then
+    error("No repl definition for this filetype!")
+  end
   local block_deviders = config.repl_definition[vim.bo[0].filetype].block_deviders
   if block_deviders == nil then
     error("No block_deviders defined for this repl in repl_definition!")

--- a/lua/iron/core.lua
+++ b/lua/iron/core.lua
@@ -151,6 +151,23 @@ core.repl_restart = function()
   end
 end
 
+core.clear_repl = function(ft)
+  local meta = vim.b[0].repl
+
+  if not meta or not ll.repl_exists(meta) then
+    ft = ft or ll.get_buffer_ft(0)
+    meta = ll.get(ft)
+  end
+
+  if not ll.repl_exists(meta) then
+    return
+  end
+
+  -- bypass all formatters, otherwise bracked_paste_python replaces FF with CR
+  --  FYI this may be a problem for windows installs b/c there's special logic in send to handle windows buffer/cursors positions?
+  vim.fn.chansend(meta.job, string.char(12))
+end
+
 --- Sends a close request to the repl
 -- if @{config.values.close_window_on_exit} is set to true,
 -- all windows associated with that repl will be closed.
@@ -717,7 +734,7 @@ local named_maps = {
   cr = { { 'n' }, function() core.send(nil, string.char(13)) end },
   interrupt = { { 'n' }, function() core.send(nil, string.char(03)) end },
   exit = { { 'n' }, core.close_repl },
-  clear = { { 'n' }, function() core.send(nil, string.char(12)) end },
+  clear = { { 'n' }, core.clear_repl },
 }
 
 local tmp_migration = {


### PR DESCRIPTION
When using bracketed_paste_python with `ipython` and `python3` the formatter calls `remove_empty_lines` which replaces `FF` with `CR` 

https://github.com/g0t4/iron.nvim/blob/d8c2869/lua/iron/fts/common.lua#L119-L120

I split out a new `core.clear_repl` function, similar to `core.close_repl` and in there I bypass using `.send_to_repl` and instead go to `chansend` directly.

I have not yet investigated the implications for this on Windows, I am happy to help with that if this is the right direction to go with a fix for this.

And if I am not doing something else wrong. 

Btw, clear works fine for `lua` and other REPLs that don't override the formatter.