### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ iron.setup {
       -- return "iron"
     end,
     -- Send selections to the DAP repl if an nvim-dap session is running.
-    dap_integration = true
+    dap_integration = true,
     -- How the repl window will be displayed
     -- See below for more information
     repl_open_cmd = view.bottom(40),


### PR DESCRIPTION
there's a missing comma in the default config given in the readme