### PR TITLE
Fix indentation error in Python 3.13+ built-in REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ iron.setup {
         command = { "python3" },  -- or { "ipython", "--no-autoindent" }
         format = common.bracketed_paste_python,
         block_dividers = { "# %%", "#%%" },
-        env = {PYTHON_BASIC_REPL = "1"} --this is needed for python3.13 and up.
+        is_new_repl = true -- this must be set to true for Python 3.13 and later.
       }
     },
     -- set the file type of the newly created repl to ft


### PR DESCRIPTION
In Python 3.13 and later, the built-in REPL automatically adjusts indentation based on contextual information when a new line is entered. This behavior may cause unexpected indentation errors in some cases. The issue was previously reported in issue #424 . Fortunately, the new REPL provides a Paste Mode, which disables automatic indentation and allows code to run smoothly.
<img width="2061" height="999" alt="aa17bcc35688ed652dc773736de74aa0" src="https://github.com/user-attachments/assets/f49064db-026b-4ccd-91a5-bb2c3b3f1e1b" />
This implementation runs smoothly on Windows and Linux. The new REPL includes built-in syntax highlighting and more powerful features. With the implementations in PRs #435  and #436 , setting PYTHON_BASIC_REPL is no longer required.