### PR TITLE
Update shell ft checking

### DIFF
--- a/lua/iron/fts/sh.lua
+++ b/lua/iron/fts/sh.lua
@@ -1,15 +1,22 @@
 local sh = {}
 
-sh.zsh = {
-  command = {"zsh"},
-}
-
 sh.bash = {
   command = {"bash"},
 }
 
 sh.sh = {
-  command = {"sh"},
+  command = function(meta)
+    local bufnr = meta.current_bufnr
+    if vim.b[bufnr].is_posix == 1 then
+      return {"sh"}
+    elseif vim.b[bufnr].is_bash == 1 then
+      return {"bash"}
+    elseif vim.b[bufnr].is_kornshell == 1 then
+      return {"ksh"}
+    else
+      return {"sh"}
+    end
+  end,
 }
 
 return sh


### PR DESCRIPTION
Neovim sets the filetype of shell scripts to sh regardless of whether it's bash or ksh. Instead, these variables are set as shown in <https://neovim.io/doc/user/syntax.html#ft-sh-syntax>: `g:is_bash` `g:is_dash` `g:is_kornshell` `g:is_posix` `g:is_sh`.

This PR updates the sh command to check these variables and call the correct command. zsh, csh etc. are unaffected since neovim sets their filetypes to `zsh` `csh` etc.