### PR TITLE
fix(view): use current window option API

### DIFF
--- a/lua/iron/view.lua
+++ b/lua/iron/view.lua
@@ -110,7 +110,7 @@ view.split = with_nested_metatable{ mode = function(data, size, options)
 
     local winid = vim.fn.bufwinid(bufnr)
     for opt, val in pairs(with_defaults(options)) do
-      vim.api.nvim_win_set_option(winid, opt, val)
+      vim.api.nvim_set_option_value(opt, val, { win = winid })
     end
     return winid
   end


### PR DESCRIPTION
## Summary

Use the current Neovim API for split-window options.

## Why

[`nvim_win_set_option()` is deprecated](https://neovim.io/doc/user/deprecated/#deprecated-0.10).

## What changed

- Pass the target window to `nvim_set_option_value()`.

## Testing

- `make test` (22 tests passed)
- Luacheck

## Related Issue(s)

None.
